### PR TITLE
feat(paved-paths): e2e bootstrap + guidance hardening

### DIFF
--- a/bin/explore-paved-paths.mjs
+++ b/bin/explore-paved-paths.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env zx
+
+// Bootstrap an interactive paved-paths testing environment.
+//
+// Creates a temporary working directory with:
+//   - moxyfile.paved-paths.json (two-stage orient → edit, or caller-supplied)
+//   - .mcp.json (moxy MCP server pointing at the local build)
+//   - .claude/settings.json (all builtin tools denied; only this moxy enabled)
+//   - logs/ (moxy stderr logs via XDG_LOG_HOME)
+//
+// Launches claude directly in that directory. On exit, removes the temp dir.
+//
+// Usage:
+//   zx bin/explore-paved-paths.mjs
+//   zx bin/explore-paved-paths.mjs --json path/to/paved-paths.json
+//   just explore-paved-paths
+//   just explore-paved-paths path/to/paved-paths.json
+//
+// Requires:
+//   - build/moxy (run `just build-go` first)
+//   - result/share/moxy/moxins (run `just build-nix` first)
+
+import { spawn } from 'node:child_process'
+
+$.verbose = false
+
+const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..')
+const MOXY_BIN = path.join(REPO_ROOT, 'build', 'moxy')
+const MOXINS_DIR = path.join(REPO_ROOT, 'result', 'share', 'moxy', 'moxins')
+
+// Verify binaries exist
+if (!(await fs.pathExists(MOXY_BIN))) {
+  console.error(`error: moxy binary not found at ${MOXY_BIN}`)
+  console.error(`  run: just build-go`)
+  process.exit(1)
+}
+
+if (!(await fs.pathExists(MOXINS_DIR))) {
+  console.error(`error: moxins not found at ${MOXINS_DIR}`)
+  console.error(`  run: just build-nix`)
+  process.exit(1)
+}
+
+// Create temp working directory inside repo so .gitignore covers it
+const WORK_DIR = await fs.mkdtemp(path.join(REPO_ROOT, '.paved-paths-test-'))
+const LOG_DIR = path.join(WORK_DIR, 'logs')
+await fs.ensureDir(LOG_DIR)
+
+// --- Cleanup ---
+
+let cleaningUp = false
+async function cleanup() {
+  if (cleaningUp) return
+  cleaningUp = true
+  await fs.remove(WORK_DIR).catch(() => {})
+  console.log('Cleaned up.')
+}
+
+let signalReceived = false
+async function handleSignal(code) {
+  if (signalReceived) return
+  signalReceived = true
+  await cleanup()
+  process.exit(code)
+}
+
+process.on('SIGINT', () => handleSignal(130))
+process.on('SIGTERM', () => handleSignal(143))
+
+// --- Write config files ---
+
+// moxyfile.paved-paths.json
+const jsonSrc = argv.json
+if (jsonSrc) {
+  await fs.copy(jsonSrc, path.join(WORK_DIR, 'moxyfile.paved-paths.json'))
+} else {
+  await fs.writeJson(
+    path.join(WORK_DIR, 'moxyfile.paved-paths.json'),
+    [
+      {
+        name: 'onboarding',
+        description: 'Learn the repo before making changes',
+        stages: [
+          { label: 'orient', tools: ['folio.read', 'folio.glob', 'rg.search'] },
+          { label: 'edit',   tools: ['folio.write', 'grit.add', 'grit.commit'] },
+        ],
+      },
+    ],
+    { spaces: 2 },
+  )
+}
+
+// .mcp.json — moxy MCP server with logging via XDG_LOG_HOME
+await fs.writeJson(
+  path.join(WORK_DIR, '.mcp.json'),
+  {
+    mcpServers: {
+      moxy: {
+        command: MOXY_BIN,
+        args: ['serve', 'mcp'],
+        type: 'stdio',
+        env: {
+          MOXIN_PATH: MOXINS_DIR,
+          XDG_LOG_HOME: LOG_DIR,
+        },
+      },
+    },
+  },
+  { spaces: 2 },
+)
+
+// .claude/settings.json — deny all builtin Claude tools; only load this moxy
+await fs.ensureDir(path.join(WORK_DIR, '.claude'))
+await fs.writeJson(
+  path.join(WORK_DIR, '.claude', 'settings.json'),
+  {
+    enabledMcpjsonServers: ['moxy'],
+    permissions: {
+      deny: [
+        'Bash',
+        'Edit',
+        'Glob',
+        'Grep',
+        'Read',
+        'WebFetch',
+        'WebSearch',
+        'Write',
+        'Agent',
+        'NotebookEdit',
+        'EnterPlanMode',
+        'ExitPlanMode',
+        'AskUserQuestion',
+        'TaskCreate',
+        'TaskUpdate',
+        'TaskGet',
+        'TaskList',
+        'TaskOutput',
+        'TaskStop',
+        'CronCreate',
+        'CronDelete',
+        'CronList',
+        'Skill',
+        'EnterWorktree',
+        'ExitWorktree',
+        'mcp__moxy__exec-mcp',
+      ],
+    },
+  },
+  { spaces: 2 },
+)
+
+// --- Print summary and launch claude ---
+
+console.log('')
+console.log('Paved-paths test environment:')
+console.log(`  work dir:  ${WORK_DIR}`)
+console.log(`  moxy bin:  ${MOXY_BIN}`)
+console.log(`  moxins:    ${MOXINS_DIR}`)
+console.log(`  logs:      ${LOG_DIR}`)
+console.log('')
+console.log('Paved-paths config:')
+console.log(JSON.stringify(await fs.readJson(path.join(WORK_DIR, 'moxyfile.paved-paths.json')), null, 2))
+console.log('')
+
+const claude = spawn('clown', [], {
+  cwd: WORK_DIR,
+  stdio: 'inherit',
+})
+
+const exitCode = await new Promise((resolve) => {
+  claude.on('exit', (code) => resolve(code ?? 0))
+  claude.on('error', (err) => {
+    console.error(`error launching clown: ${err.message}`)
+    resolve(1)
+  })
+})
+
+await cleanup()
+process.exit(exitCode)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1297,7 +1297,8 @@ func (p *Proxy) HandlePavedPaths(args map[string]any) string {
 			if len(path.Stages) > 0 {
 				stage := path.Stages[0]
 				fmt.Fprintf(&sb, "Stage: %s\n", stage.Label)
-				fmt.Fprintf(&sb, "Tools to call:\n")
+				fmt.Fprintf(&sb, "You MUST call each of the following tools before the stage advances.\n")
+				fmt.Fprintf(&sb, "Do not ask for permission — call them now:\n")
 				for _, t := range stage.Tools {
 					fmt.Fprintf(&sb, "  - %s\n", t)
 				}
@@ -1314,12 +1315,12 @@ func (p *Proxy) HandlePavedPaths(args map[string]any) string {
 		if currentPath != nil && state.CurrentStage < len(currentPath.Stages) {
 			stage := currentPath.Stages[state.CurrentStage]
 			fmt.Fprintf(&sb, "Stage: %s\n", stage.Label)
-			fmt.Fprintf(&sb, "Tools:\n")
+			fmt.Fprintf(&sb, "You MUST call each unchecked tool to advance. Call them now:\n")
 			for _, t := range stage.Tools {
 				if state.CalledTools[t] {
-					fmt.Fprintf(&sb, "  \u2713 %s\n", t)
+					fmt.Fprintf(&sb, "  \u2713 %s (done)\n", t)
 				} else {
-					fmt.Fprintf(&sb, "  - %s\n", t)
+					fmt.Fprintf(&sb, "  - %s (required)\n", t)
 				}
 			}
 		}

--- a/justfile
+++ b/justfile
@@ -558,6 +558,15 @@ explore-nix-tools-list: build-nix
   count=$(echo "$init_result" | tail -1 | jq '.result.tools | length' 2>/dev/null || echo "PARSE_ERROR")
   echo "Tool count: $count"
 
+# Launch claude directly in a paved-paths test workspace (all builtin tools denied, moxy only).
+# Usage: just explore-paved-paths [path-to-paved-paths.json]
+[group('explore')]
+explore-paved-paths json="":
+  #!/usr/bin/env bash
+  args=()
+  [[ -n "{{json}}" ]] && args+=(--json "{{json}}")
+  exec zx {{justfile_directory()}}/bin/explore-paved-paths.mjs "${args[@]}"
+
 # Test install-moxin.bash extraction logic against local nix build artifacts.
 # Replicates the script's extract steps without hitting GitHub or brew.
 # Usage: just debug-install-moxin piers


### PR DESCRIPTION
## Summary

Adds an interactive e2e bootstrap script for testing the paved-paths feature, and hardens the guidance text the model sees when a path is selected.

## Changes

**`bin/explore-paved-paths.mjs`** — launches `clown` in an isolated temp workdir containing:
- `moxyfile.paved-paths.json` (default two-stage `orient → edit`, or `--json` override)
- `.mcp.json` pointing at the local moxy build with `XDG_LOG_HOME` for moxy stderr logs
- `.claude/settings.json` denying all builtin Claude tools, enabling only this moxy, and denying `exec-mcp` so the paved-path filter is exercised

Follows the `bin/serve-http.mjs` / `caldav bootstrap.mjs` pattern.

**`justfile`** — thin `explore` group recipe: `just explore-paved-paths [path-to-paved-paths.json]`

**`internal/proxy/proxy.go`** — hardened `HandlePavedPaths` response text to use imperative language ("You MUST call each of the following tools... call them now") on both `select` and status responses.

## Known issue

After path selection, `tools/listChanged` fires but stage-gated tools don't appear in the model's tool list. Suspected causes:
1. Race between `SetPavedPaths` and `p.SetNotifier(t.Write)` in `runServer` — notification fires before the transport notifier is wired
2. Claude Code / clown not re-fetching `tools/list` in response to the notification

Under investigation. Leaving as draft until resolved.

---
*🤡 Opened by [Clown](https://github.com/amarbel-llc/clown)*