### PR TITLE
[WIP] Phase B: fold golangci-lint into the unified treelint check gate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,12 @@
         # RFC 0001 §Compatibility). Take treefmt-nix's generated formatter
         # config and append moxy's [linter.*] sections — treefmt has no linter
         # table, so a plain append is a valid, order-independent merge.
+        #
+        # golangci-lint is a whole-tree linter: passes-files = false means
+        # treelint runs `golangci-lint run` once at the tree root with no file
+        # args (RFC 0001 §4), gated to run only when *.go files are present. Its
+        # Go toolchain + vendored module graph are provided by treelintCheck
+        # below; non-zero exit becomes a finding.
         treelintConfig = pkgs.runCommand "treelint-config.toml" { } ''
           cat ${treefmtEval.config.build.configFile} > $out
           cat >> $out <<EOF
@@ -165,6 +171,12 @@
           [linter.dead-jq]
           command = "${deadJqChecker}/bin/lint-dead-jq"
           includes = ["zz-tests_bats/*.bats"]
+
+          [linter.golangci-lint]
+          command = "golangci-lint"
+          options = ["run"]
+          passes-files = false
+          includes = ["**/*.go"]
           EOF
         '';
 
@@ -183,15 +195,58 @@
         # sandbox (the tree must be writable for fix-only formatters' sandbox
         # checks, and we never write back to the real tree), then run
         # `treelint check` rooted at that copy. Non-zero exit fails the build.
+        #
+        # The [linter.golangci-lint] entry in the merged config is a whole-tree
+        # check that shells out to `golangci-lint run` at the tree root — which
+        # needs the Go toolchain and the vendored module graph (the type-aware
+        # linters staticcheck/unused/govet must typecheck). We reproduce
+        # gomod2nix's goConfigHook env (builder/hooks/go-config-hook.sh): hydrate
+        # vendor/ from moxy.passthru.vendorEnv, restore the warm build cache from
+        # goCacheEnv, and set the offline Go env (GOPROXY=off, -mod=vendor,
+        # GO_NO_VENDOR_CHECKS=1). CGO_ENABLED=0 because moxy's module has no cgo
+        # (the cgo embedding package lives in maneater, a separate module).
         treelintCheck =
           pkgs.runCommand "treelint-check"
             {
-              nativeBuildInputs = [ treelintBin ];
+              nativeBuildInputs = [
+                treelintBin
+                moxy.passthru.go
+                pkgs-master.golangci-lint
+                pkgs.rsync
+                pkgs.zstd
+                pkgs.gnutar
+              ];
             }
             ''
               cp -r ${self} src
               chmod -R u+w src
               cd src
+
+              # Offline Go env for golangci-lint's package loader, mirroring
+              # gomod2nix's goConfigHook.
+              export GOCACHE="$TMPDIR/go-cache"
+              export GOPATH="$TMPDIR/go"
+              export GOSUMDB=off
+              export GOPROXY=off
+              export GO_NO_VENDOR_CHECKS=1
+              export GO111MODULE=on
+              export GOTOOLCHAIN=local
+              export CGO_ENABLED=0
+              export GOFLAGS="-mod=vendor -trimpath"
+              export GOLANGCI_LINT_CACHE="$TMPDIR/golangci-lint"
+              # Match the test-go/lint-go environment: package loading must not
+              # see the moxin tree (moxy#... parity with `MOXIN_PATH=""`).
+              export MOXIN_PATH=""
+
+              echo "Setting up vendor directory from ${moxy.passthru.vendorEnv}"
+              rm -rf vendor
+              rsync -a -K --ignore-errors ${moxy.passthru.vendorEnv}/ vendor
+
+              echo "Restoring Go build cache from ${moxy.passthru.goCacheEnv}/cache.tar.zst"
+              mkdir -p "$GOCACHE"
+              zstd -d -c ${moxy.passthru.goCacheEnv}/cache.tar.zst | tar -xf - -C "$GOCACHE"
+              chmod -R +w "$GOCACHE"
+
               treelint check \
                 --config-file ${treelintConfig} \
                 --tree-root .


### PR DESCRIPTION
## Status: WIP / BLOCKED — do not merge

Phase B of the treelint adoption: collapse `just lint-go` into the single
`treelint check` gate by running golangci-lint as a treelint **whole-tree
linter** (`passes-files = false`). Phase A (treelint as `nix fmt` runner + gate,
plus the dead-jq bats linter) already merged to `master` in `c3e581b`.

This PR captures the in-progress Phase B wiring. **It does not work yet** and is
filed as a draft checkpoint, not for merge — `checks.treelint` currently fails.

## What is wired (commit `11fa7e2`)

- **`[linter.golangci-lint]`** in the merged `treelintConfig`: `command =
  "golangci-lint"`, `options = ["run"]`, `passes-files = false`,
  `includes = ["**/*.go"]`. treelint invokes `golangci-lint run` **once** at the
  tree root with no file args (RFC 0001 §4), gated to run only when `*.go` files
  are present.
- **`treelintCheck` Go-enabled**: adds `moxy.passthru.{go,vendorEnv,goCacheEnv}`
  + `golangci-lint` to the sandbox, and replicates gomod2nix's `goConfigHook`
  env (`GOPROXY=off`, `-mod=vendor`, `GO_NO_VENDOR_CHECKS=1`, `CGO_ENABLED=0`,
  vendor/ hydrated from `vendorEnv`, warm `GOCACHE` restored from `goCacheEnv`).

`lint-go` is intentionally **still in the `lint` aggregate** — it is not
collapsed until golangci-lint actually runs through treelint.

## Blocker (confirmed root cause)

```
typechecking error: named files must all be in one directory;
have cmd/moxy and cmd/moxy-exporel-dynamic-perms
```

golangci-lint's `go/packages` loader under `-mod=vendor` needs
`vendor/modules.txt`, but gomod2nix's `mkVendorEnv` generates `modules.txt`
**only for workspace builds** (`mkWorkspaceModulesTxt`, gated on
`goWork != null`; see `amarbel-llc/gomod2nix` `builder/default.nix:112-166`).
moxy is a **non-workspace** build (`modules = ./gomod2nix.toml`), so its
`vendorEnv` has no `modules.txt`. moxy's own `go build` tolerates this via
`GO_NO_VENDOR_CHECKS=1`, but golangci-lint falls back to globbing `.go` files
across directories and fails. The same `golangci-lint run` works in the devshell
(`just lint-go`) because `mkGoEnv` sets up the environment differently than this
PR's hand-rolled `goConfigHook` replication.

## Open fix options (to evaluate on resume)

1. **Synthesize `vendor/modules.txt`** in the `treelintCheck` builder before
   running golangci-lint (gomod2nix has the generation logic, but only wired for
   workspaces). Risk: must enumerate every module + package exactly or
   `-mod=vendor` rejects the tree.
2. **Reuse `mkGoEnv`'s working environment** in a `runCommand` instead of
   hand-rolling `goConfigHook` — more faithful to the setup that demonstrably
   makes `golangci-lint run` work, but `mkGoEnv` is a devshell helper.
3. **Keep `lint-go` in the devshell**; defer true nesting until
   [treelint#4](https://github.com/amarbel-llc/treelint/issues/4) (the treelint
   Nix module) lands, which would replace the hand-rolled config-merge + sandbox
   plumbing with a declarative module.
4. Investigate loading packages without vendor (`-mod=mod` + a `GOMODCACHE`
   exposing the gomod2nix module sources).

## Verification (once unblocked)

- `just lint-fmt` (builds `checks.treelint`) green; build log shows treelint
  invoking golangci-lint once.
- Non-vacuous: inject a deliberate staticcheck/unused violation in
  `internal/**/*.go` → gate FAILS with the finding; revert.
- Parity with the old `lint-go` ruleset + `.golangci.yml` exclusions.
- Collapse `lint: lint-fmt lint-go` → `lint: lint-fmt`; drop the `lint-go`
  recipe; full `just default` green.

🤡 via [Clown](https://github.com/amarbel-llc/clown)